### PR TITLE
paths for repo transfer: protomaps -> maplibre

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 The WASM outputs `sdfglyph.js` and `sdfglyph.wasm` are not committed to git. To develop the web app locally download the compiled ones from GitHub pages:
 
-* [sdfglyph.js](https://protomaps.github.io/font-maker/sdfglyph.js)
-* [sdfglyph.wasm](https://protomaps.github.io/font-maker/sdfglyph.wasm)
+* [sdfglyph.js](https://maplibre.org/font-maker/sdfglyph.js)
+* [sdfglyph.wasm](https://maplibre.org/font-maker/sdfglyph.wasm)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For other prepared fonts, look at [maplibre/demotiles/font](https://github.com/m
 
 ## Usage
 
-* Go to the web app at [protomaps.github.io/font-maker/](https://protomaps.github.io/font-maker/) and select your file.
+* Go to the web app at [maplibre.org/font-maker/](https://maplibre.org/font-maker/) and select your file.
 
 * Wait for the progress bar to complete and download your ZIP containing all ranges for the font. 
 

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MapLibre Font Maker</title>
+    <title>Font Maker</title>
   </head>
   <body>
     <style>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -260,7 +260,7 @@ function App() {
           </div>
         </div>
         <div className="flex-grow-0">
-          <a href="https://github.com/protomaps/font-maker" target="_blank">
+          <a href="https://github.com/maplibre/font-maker" target="_blank">
             <img src="github.svg"></img>
           </a>
         </div>


### PR DESCRIPTION
Changes proposed in this pull request:

- fix references in links, docs to old protomaps/font-maker path, revise to maplibre/font-maker

@bdon
