### PR TITLE
Use hardwired baseline to match MapLibre behavior

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,12 +37,14 @@ void do_codepoint(protozero::pbf_writer &parent, std::vector<FT_Face> &faces, FT
                 glyph_message.add_uint32(1,static_cast<uint32_t>(char_code));
             }
 
-            // double to int
-            double top = static_cast<double>(glyph.top) - glyph.ascender;
+            // node-fontnik uses glyph.top - glyph.ascender, assuming that the baseline
+            // will be based on the ascender. However, Mapbox/MapLibre shaping assumes
+            // a baseline calibrated on DIN Pro w/ ascender of ~25 at 24pt
+            int32_t top = glyph.top - 25;
             if (top < numeric_limits<int32_t>::min() || top > numeric_limits<int32_t>::max()) {
-                throw runtime_error("Invalid value for glyph.top-glyph.ascender");
+                throw runtime_error("Invalid value for glyph.top-25");
             } else {
-                glyph_message.add_sint32(6,static_cast<int32_t>(top));
+                glyph_message.add_sint32(6,top);
             }
 
             // double to uint


### PR DESCRIPTION
node-fontnik always encoded glyph "top" metrics relative to the typeface's ascender, but it didn't actually tell the client what the ascender/descender was, so there was no way for Mapbox GL (and by extension MapLibre) to know what baseline to use. Mapbox effectively calibrated the baseline for its shaping code on DIN Pro, which has an ascender of 25 at 24pts (the font is proprietary, but you can see stats [here](https://fontsgeek.com/fonts/DINPro-Regular)).

You can see historical discussion at https://github.com/mapbox/mapbox-gl-js/issues/191

There is a (open-source) PR to node-fontnik to expose the data at https://github.com/mapbox/node-fontnik/pull/160, but it hasn't merged.

Post-fork, Mapbox GL implemented ascender/descender awareness -- I won't link to the PR here to avoid contamination concerns. I was actually a reviewer on the PR but have forgotten most of the details and don't think I should look at the code now. However, I think (??) one of the concerns was that in order to correctly handle verticalizing glyphs (for CJK labels that support vertical alignment) you need to know the actual baseline to know how to do your rotation.

What I haven't figured out is why Mapbox (including me while I was there) never just modified node-fontnik to do the simplest thing imaginable -- just use the "top" metric directly from the font without an ascender modification! My best guess is that we talked a lot about doing it the "right" way (including ascender metadata), but never looked for a fast fix because most of the fonts we used were close enough to the DIN Pro ascender that they looked OK? But honestly I think I may be missing/forgetting something.

At any rate, this PR does that simple thing -- it just returns the glyph's "top" metric, with an offset of 25 to account for the implicit DIN-Pro derived ascender baked into the renderer.

Here's a map before the change -- you can see that Atlas Grotesk on its own isn't properly centered in the collision box, and you can see when it's put next to Noto Sans Arabic, the baselines are way off:

<img width="369" alt="Screenshot 2023-02-20 at 3 07 14 PM" src="https://user-images.githubusercontent.com/375121/220215127-9683c1c4-839f-428f-93de-2e4464f8c2fc.png">

And here's the map with the fonts re-generated using this change:

<img width="438" alt="Screenshot 2023-02-20 at 3 07 47 PM" src="https://user-images.githubusercontent.com/375121/220215180-335e8f6f-7402-4515-8e97-51594b8b35f8.png">

This change will affect all fonts generated with font-maker, so it would be good to test with a wide range to see if we're getting the better alignment we expect.

@bdon
