### PR TITLE
Fix CLI build errors, closes #36

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(font-maker)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -g")
+set(CMAKE_CXX_FLAGS "-Wno-c++11-narrowing")
 
 find_package(Boost 1.73 REQUIRED)
 find_package(Freetype REQUIRED)


### PR DESCRIPTION
Fixes #36.

Changes proposed in this pull request:

- Add Flag to ignore type narrowing errors in clang++

@bdon
